### PR TITLE
Fix typo for variable name on cpt labels

### DIFF
--- a/build/wp-content/mu-plugins/mkdo-core/php/post-types/example-cpt-review.php
+++ b/build/wp-content/mu-plugins/mkdo-core/php/post-types/example-cpt-review.php
@@ -42,7 +42,7 @@ $mkdo_core_review_labels = array(
 $mkdo_core_review_args = array(
 	'label'               => __( 'Reviews', 'mkdo-core' ),
 	'description'         => __( 'Custom Post Type for Review', 'mkdo-core' ),
-	'labels'              => $review_labels,
+	'labels'              => $mkdo_core_review_labels,
 	'supports'            => array(
 		'title',
 		'editor',

--- a/build/wp-content/mu-plugins/mkdo-core/php/taxonomies/example-tax-review-category.php
+++ b/build/wp-content/mu-plugins/mkdo-core/php/taxonomies/example-tax-review-category.php
@@ -8,7 +8,7 @@
  */
 
 // Unique variable name.
-$mkdo_core_review_category_labels = array(
+$mkdo_core_category_labels = array(
 	'name'                  => __( 'Categories', 'mkdo-core' ),
 	'singular_name'         => __( 'Category', 'mkdo-core' ),
 	'search_items'          => __( 'Search Categories', 'mkdo-core' ),
@@ -39,4 +39,4 @@ $mkdo_core_category_args = array(
 	'rewrite'           => true,
 );
 
-register_taxonomy( 'review_category', 'review', $mkdo_core_review_category_args );
+register_taxonomy( 'review_category', 'review', $mkdo_core_category_args );


### PR DESCRIPTION
Just corrected the variable name to pull in labels on the example CPT file.